### PR TITLE
Add option to set # hidden units in RNN layer.

### DIFF
--- a/include/caffe/sequence_layers.hpp
+++ b/include/caffe/sequence_layers.hpp
@@ -36,6 +36,8 @@ class RecurrentLayer : public Layer<Dtype> {
   virtual inline int MinBottomBlobs() const { return 2; }
   virtual inline int MaxBottomBlobs() const { return 3; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline shared_ptr<Net<Dtype> > UnrolledNet() const { return unrolled_net_; }
+
 
   virtual inline bool AllowForceBackward(const int bottom_index) const {
     // Can't propagate to sequence continuation indicators.

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -728,6 +728,8 @@ message RNNParameter {
   optional string output_nonlinearity = 1 [default = "TanH"];
   // Nonlinearity on recurrent state (h_t)
   optional string recurrent_nonlinearity = 2 [default = "TanH"];
+  // Number of hidden units. 0 (default) means use num_output from RecurrentParameter
+  optional uint32 num_hidden = 3 [default = 0];
 }
 
 // Message that stores parameters used by ReLULayer


### PR DESCRIPTION
Another small change to the RNN layer.

This adds a prototxt option "num_hidden" to change the number of hidden units in the RNN layer. If left to default, num_output will be used so original behavior is preserved.
